### PR TITLE
Add EditorConfig and Force LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
+[*.{c,h}]
+indent_style = tab
+indent_size = 8
+
 [*.ld]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.ld]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
**When merged this pull request will:**
- Change default EOL to LF for EditorConfig and Git setting (in case where `core.autocrlf` is not enabled).
- Add EditorConfig for indentation and setting Git-friendly editor settings.