### PR TITLE
Organized GPUs by generational PCI ID ranges.

### DIFF
--- a/vgpu_unlock
+++ b/vgpu_unlock
@@ -314,6 +314,11 @@ script_source = r"""
                     syslog("op_type: 0x" + op_type.toString(16) + " failed.");
                 }
             }
+
+            // Workaround for some Maxwell cards not supporting reading inforom.
+            if(op_type == 0x2080014b && status == 0x56) {
+                this.argp.add(0x1C).writeU32(0x57);
+            }
         }
     });
 

--- a/vgpu_unlock
+++ b/vgpu_unlock
@@ -131,6 +131,7 @@ script_source = r"""
                    actual_devid == 0x13bb || // Quadro K620
                    actual_devid == 0x13bc) { // Quadro K1200               
                     spoofed_devid = 0x13bd; // Tesla M10
+                    spoofed_subsysid = 0x1160;
                 }
 
                 // GM204

--- a/vgpu_unlock_hooks.c
+++ b/vgpu_unlock_hooks.c
@@ -739,7 +739,7 @@ static vgpu_unlock_vgpu_t vgpu_unlock_vgpu[] =
 	VGPU(0x1e30, 0x1440, "GRID RTX6000-24A"),
 
 	/* RTX A6000 (Ampere) */
-	VGPU(0x2230, 0x14fa, "NVIDIA RTX A6000-1B"),
+	VGPU(0x2230, 0x14fa, "NVIDIA RTXA6000-1B"),
 	VGPU(0x2230, 0x14fb, "NVIDIA RTXA6000-2B"),
 	VGPU(0x2230, 0x14fc, "NVIDIA RTXA6000-1Q"),
 	VGPU(0x2230, 0x14fd, "NVIDIA RTXA6000-2Q"),

--- a/vgpu_unlock_hooks.c
+++ b/vgpu_unlock_hooks.c
@@ -597,7 +597,7 @@ vgpu_unlock_vgpu_t;
 
 static vgpu_unlock_vgpu_t vgpu_unlock_vgpu[] =
 {
-	/* Tesla M10 (Maxwell 1.0) */
+	/* Tesla M10 (Maxwell) */
 	VGPU(0x13bd, 0x11cc, "GRID M10-0B"),
 	VGPU(0x13bd, 0x11cd, "GRID M10-1B"),
 	VGPU(0x13bd, 0x1339, "GRID M10-1B4"),


### PR DESCRIPTION
This now makes the scripts more compact as there are conditional statements selecting the vGPU profile enabled card by the generation, and the generation is determined by the ranges of PCI IDs. This should eliminate the need for adding PCI IDs manually now, and open up more profile options for users to pick from, including profiles with a VRAM multiple of 3GB. Note that it breaks compatibility with previous versions as users may have to go back and reselect a new profile.